### PR TITLE
feat: prevent more than one message at once

### DIFF
--- a/components/app-prompt-input.vue
+++ b/components/app-prompt-input.vue
@@ -3,13 +3,16 @@ const props = defineProps<{ modelValue: string }>()
 const emit = defineEmits(['update:modelValue', 'send'])
 
 const { apiKey } = useSettings()
+const { isTyping } = useConversations()
 // const { currentPreset, clearPreset } = usePreset()
 const textarea = ref()
 const isLogged = computed(() => Boolean(apiKey.value))
 
 const onSend = () => {
-    emit('send', props.modelValue)
-    emit('update:modelValue', '')
+    if (!isTyping.value) {
+        emit('send', props.modelValue)
+        emit('update:modelValue', '')
+    }
 }
 
 const onType = (event?: any) => {
@@ -70,7 +73,12 @@ const handleEnter = (e: KeyboardEvent) => {
                 :disabled="!isLogged"
                 @click="onSend"
             >
-                <div i-tabler-send text-5 />
+                <div
+                    text-5
+                    :class="[
+                        !isTyping ? 'i-tabler-send' : 'i-eos-icons-bubble-loading',
+                    ]"
+                />
             </UButton>
         </div>
     </div>

--- a/components/app-sidebar.vue
+++ b/components/app-sidebar.vue
@@ -49,7 +49,7 @@ const onOpenKnowledgeManager = () => {
                 {{ conversationList?.length }} conversations
             </div>
         </div>
-        <div max-h-100 overflow-y-auto overflow-x-hidden w-full>
+        <div max-h-100 overflow-y-auto overflow-x-hidden w-full pb-2>
             <ConversationTab
                 v-for="conversation in conversationsSortedByUpdatedAt"
                 :key="conversation.id"
@@ -89,7 +89,7 @@ const onOpenKnowledgeManager = () => {
                 @click="navigateTo('/settings/api-key')"
             />
             <div
-                text-gray-4 dark:text-dark-1 my-6 text-5 tracking--1px w-full
+                text-color-lighter my-6 text-5 tracking--1px w-full
                 flex-col flex justify-center items-center
             >
                 <div font-black>


### PR DESCRIPTION
## Summary of Pull Request

### Changes to `app-prompt-input.vue`
- Added a new import and a new variable called `isTyping`.
- Modified the `onSend` function to check if `isTyping` is false before sending the message.
- Modified the send button to show a loading icon when `isTyping` is true.

### Changes to `app-sidebar.vue`
- Modified a div element to include a `pb-2` class.
- Changed the `text-gray-4` class to `text-color-lighter`.

## How
The changes made to `app-prompt-input.vue` involved adding a new import statement and a new variable called `isTyping`. The `onSend` function was also modified to check if `isTyping` is false before sending the message. Finally, the send button was modified to show a loading icon when `isTyping` is true. 

In `app-sidebar.vue`, a div element was modified to include a `pb-2` class and the `text-gray-4` class was changed to `text-color-lighter`.

## Why
The changes made to `app-prompt-input.vue` were made to improve the user experience by showing a loading icon when the user is typing a message. This helps to prevent the user from sending multiple messages at once. 

The changes made to `app-sidebar.vue` were made to improve the appearance of the sidebar in the application.