### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/plugins/floating-vue.ts
+++ b/plugins/floating-vue.ts
@@ -1,5 +1,5 @@
 import FloatingVue from 'floating-vue'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 import 'floating-vue/dist/style.css'
 
 export default defineNuxtPlugin(({ vueApp }) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.